### PR TITLE
Django 1.9 fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     pass
 
-VERSION = '0.4.6'
+VERSION = '0.4.6a'
 
 if __name__ == '__main__':
     setup(
@@ -37,6 +37,7 @@ if __name__ == '__main__':
         install_requires = (
             'Django>=1.5',
             'django-tastypie>=0.13.3',
+            'future',
             'mongoengine>=0.8.8',
             'python-dateutil>=2.1',
             'lxml',
@@ -49,6 +50,7 @@ if __name__ == '__main__':
         tests_require = (
             'Django>=1.5',
             'django-tastypie>=0.13.3',
+            'future',
             'mongoengine>=0.8.8',
             'python-dateutil>=2.1',
             'lxml',

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ if __name__ == '__main__':
         zip_safe = False,
         install_requires = (
             'Django>=1.5',
-            'django-tastypie>=0.9.12',
-            'mongoengine>=0.8.1,<0.8.2',
+            'django-tastypie>=0.13.3',
+            'mongoengine>=0.8.8',
             'python-dateutil>=2.1',
             'lxml',
             'defusedxml',
@@ -48,8 +48,8 @@ if __name__ == '__main__':
         test_suite = 'tests.runtests.runtests',
         tests_require = (
             'Django>=1.5',
-            'django-tastypie>=0.9.12',
-            'mongoengine>=0.8.1,<0.8.2',
+            'django-tastypie>=0.13.3',
+            'mongoengine>=0.8.8',
             'python-dateutil>=2.1',
             'lxml',
             'defusedxml',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     pass
 
-VERSION = '0.4.6a'
+VERSION = '0.4.7'
 
 if __name__ == '__main__':
     setup(

--- a/tastypie_mongoengine/fields.py
+++ b/tastypie_mongoengine/fields.py
@@ -1,3 +1,5 @@
+from past.builtins import basestring
+from builtins import object
 import tastypie
 from tastypie import bundle as tastypie_bundle, exceptions, fields
 
@@ -175,7 +177,7 @@ class EmbeddedListField(BuildRelatedMixin, fields.ToManyField):
             return data
 
         data['embedded'].update({
-            'resource_types': type_map.keys(),
+            'resource_types': list(type_map.keys()),
         })
 
         return data
@@ -304,7 +306,7 @@ class ReferencedListField(TastypieMongoengineMixin, fields.ToManyField):
         # We are ignoring any extra fields not present in resource
         # We delete them because otherwise resource_from_data fail
         # when using getattr and they are missing in resource
-        for k in data.keys():
+        for k in list(data.keys()):
             if not hasattr(fk_resource, k):
                 del data[k]
 

--- a/tastypie_mongoengine/fields.py
+++ b/tastypie_mongoengine/fields.py
@@ -1,4 +1,3 @@
-from past.builtins import basestring
 from builtins import object
 import tastypie
 from tastypie import bundle as tastypie_bundle, exceptions, fields

--- a/tastypie_mongoengine/resources.py
+++ b/tastypie_mongoengine/resources.py
@@ -5,7 +5,7 @@ import sys
 from django.conf import urls
 from django.core import exceptions, urlresolvers
 from django.db.models import base as models_base
-from django.utils import datastructures
+from collections import OrderedDict
 
 try:
     # Django 1.5+
@@ -51,7 +51,7 @@ class NOT_HYDRATED(object):
     pass
 
 
-class ListQuerySet(datastructures.SortedDict):
+class ListQuerySet(OrderedDict):
     # Workaround for https://github.com/toastdriven/django-tastypie/pull/670
     query = Query()
 

--- a/tastypie_mongoengine/resources.py
+++ b/tastypie_mongoengine/resources.py
@@ -720,7 +720,7 @@ class MongoEngineResource(with_metaclass(MongoEngineModelDeclarativeMetaclass, r
                 'attribute': name,
                 'unique': f.unique or primary_key,
                 'null': not f.required and not primary_key,
-                'help_text': f.help_text,
+                'help_text': getattr(f, 'help_text', None),
             }
 
             # If field is not required, it does not matter if set default value,

--- a/tastypie_mongoengine/resources.py
+++ b/tastypie_mongoengine/resources.py
@@ -142,7 +142,7 @@ class ListQuerySet(OrderedDict):
         # Tastypie access object_list[0], so we pretend to be
         # a list here (order is same as our iteration order)
         if isinstance(key, (int, long)):
-            return itertools.islice(self, key, key + 1).next()
+            return next(itertools.islice(self, key, key + 1))
         # Tastypie also access sliced object_list in paginator
         elif isinstance(key, slice):
             return itertools.islice(self, key.start, key.stop, key.step)
@@ -161,14 +161,14 @@ def trim(docstring):
     # and split into a list of lines:
     lines = docstring.expandtabs().splitlines()
     # Determine minimum indentation (first line doesn't count):
-    indent = sys.maxint
+    indent = sys.maxsize
     for line in lines[1:]:
         stripped = line.lstrip()
         if stripped:
             indent = min(indent, len(line) - len(stripped))
     # Remove indentation (first line is special):
     trimmed = [lines[0].strip()]
-    if indent < sys.maxint:
+    if indent < sys.maxsize:
         for line in lines[1:]:
             trimmed.append(line[indent:].rstrip())
     # Strip off trailing and leading blank lines:
@@ -302,7 +302,7 @@ class MongoEngineResource(resources.ModelResource):
                     pass
             # the uri wasn't found at any of the polymorphic resources, it is an incorrect URI for this resource
             raise
-        except Exception, e:
+        except Exception as e:
             raise e
 
     # Data preparation.

--- a/tastypie_mongoengine/resources.py
+++ b/tastypie_mongoengine/resources.py
@@ -23,11 +23,7 @@ from tastypie import bundle as tastypie_bundle, exceptions as tastypie_exception
 
 import mongoengine
 from mongoengine import fields as mongoengine_fields, queryset
-try:
-    from mongoengine.queryset import tranform as mongoengine_tranform
-except ImportError:
-    mongoengine_tranform = None
-
+from mongoengine.queryset.transform import MATCH_OPERATORS
 from tastypie_mongoengine import fields as tastypie_mongoengine_fields
 
 from tastypie.exceptions import NotFound
@@ -38,13 +34,8 @@ from django.core.urlresolvers import Resolver404
 # We use a mock Query object to provide the same interface and return query terms by MongoEngine.
 # MongoEngine code might not expose these query terms, so we fallback to hard-coded values.
 
-QUERY_TERMS_ALL = getattr(mongoengine_tranform, 'MATCH_OPERATORS', (
-    'ne', 'gt', 'gte', 'lt', 'lte', 'in', 'nin', 'mod', 'all', 'size', 'exists', 'not', 'within_distance', 'within_spherical_distance', 'within_box', 'within_polygon', 'near', 'near_sphere', 'contains', 'icontains', 'startswith', 'istartswith', 'endswith', 'iendswith', 'exact', 'iexact', 'match'
-))
-
-
 class Query(object):
-    query_terms = dict([(query_term, None) for query_term in QUERY_TERMS_ALL])
+    query_terms = set(MATCH_OPERATORS) 
 
 if not hasattr(queryset.QuerySet, 'query'):
     queryset.QuerySet.query = Query()

--- a/tastypie_mongoengine/resources.py
+++ b/tastypie_mongoengine/resources.py
@@ -8,7 +8,7 @@ import sys
 from django.conf import urls
 from django.core import exceptions, urlresolvers
 from django.db.models import base as models_base
-#from future.utils import with_metaclass
+from future.utils import with_metaclass
 try:
     # Before Django 1.8
     from django.utils.datastructures import SortedDict as OrderedDict

--- a/tastypie_mongoengine/resources.py
+++ b/tastypie_mongoengine/resources.py
@@ -5,7 +5,12 @@ import sys
 from django.conf import urls
 from django.core import exceptions, urlresolvers
 from django.db.models import base as models_base
-from collections import OrderedDict
+try:
+    # Before Django 1.8
+    from django.utils.datastructures import SortedDict as OrderedDict
+except ImportError:
+    # After Django 1.8
+    from collections import OrderedDict
 
 try:
     # Django 1.5+

--- a/tastypie_mongoengine/resources.py
+++ b/tastypie_mongoengine/resources.py
@@ -8,7 +8,7 @@ import sys
 from django.conf import urls
 from django.core import exceptions, urlresolvers
 from django.db.models import base as models_base
-from future.utils import with_metaclass
+#from future.utils import with_metaclass
 try:
     # Before Django 1.8
     from django.utils.datastructures import SortedDict as OrderedDict

--- a/tastypie_mongoengine/test_runner.py
+++ b/tastypie_mongoengine/test_runner.py
@@ -1,4 +1,6 @@
-import urlparse
+from future import standard_library
+standard_library.install_aliases()
+import urllib.parse
 
 from django.conf import settings
 from django.test import client, simple, testcases
@@ -82,7 +84,7 @@ def requestfactory_patch(self, path, data=None, content_type=client.MULTIPART_CO
     data = data or {}
     patch_data = self._encode_data(data, content_type)
 
-    parsed = urlparse.urlparse(path)
+    parsed = urllib.parse.urlparse(path)
     request = {
         'CONTENT_LENGTH': len(patch_data),
         'CONTENT_TYPE': content_type,

--- a/tests/test_project/test_app/api/resources.py
+++ b/tests/test_project/test_app/api/resources.py
@@ -1,3 +1,4 @@
+from builtins import object
 from tastypie import authorization as tastypie_authorization, fields as tastypie_fields
 
 from tastypie_mongoengine import fields, paginator, resources
@@ -6,19 +7,19 @@ from test_project.test_app import documents
 
 
 class StrangePersonResource(resources.MongoEngineResource):
-    class Meta:
+    class Meta(object):
         queryset = documents.StrangePerson.objects.all()
         excludes = ('hidden',)
 
 
 class OtherStrangePersonResource(resources.MongoEngineResource):
-    class Meta:
+    class Meta(object):
         queryset = documents.StrangePerson.objects.all()
         excludes = ('hidden',)
 
 
 class PersonResource(resources.MongoEngineResource):
-    class Meta:
+    class Meta(object):
         # Ordering by id so that pagination is predictable
         queryset = documents.Person.objects.all().order_by('id')
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
@@ -34,7 +35,7 @@ class PersonResource(resources.MongoEngineResource):
 
 
 class PersonObjectClassResource(resources.MongoEngineResource):
-    class Meta:
+    class Meta(object):
         object_class = documents.Person
         allowed_methods = ('get', 'post')
         authorization = tastypie_authorization.Authorization()
@@ -42,7 +43,7 @@ class PersonObjectClassResource(resources.MongoEngineResource):
 
 
 class OnlySubtypePersonResource(resources.MongoEngineResource):
-    class Meta:
+    class Meta(object):
         queryset = documents.Person.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
@@ -54,12 +55,12 @@ class OnlySubtypePersonResource(resources.MongoEngineResource):
 
 
 class EmbeddedStrangePersonResource(resources.MongoEngineResource):
-    class Meta:
+    class Meta(object):
         object_class = documents.EmbeddedStrangePerson
 
 
 class EmbeddedPersonResource(resources.MongoEngineResource):
-    class Meta:
+    class Meta(object):
         object_class = documents.EmbeddedPerson
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
@@ -73,7 +74,7 @@ class EmbeddedPersonResource(resources.MongoEngineResource):
 
 
 class IndividualResource(resources.MongoEngineResource):
-    class Meta:
+    class Meta(object):
         queryset = documents.Individual.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
@@ -81,7 +82,7 @@ class IndividualResource(resources.MongoEngineResource):
 
 
 class CompanyResource(resources.MongoEngineResource):
-    class Meta:
+    class Meta(object):
         queryset = documents.Company.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
@@ -89,7 +90,7 @@ class CompanyResource(resources.MongoEngineResource):
 
 
 class UnregisteredCompanyResource(resources.MongoEngineResource):
-    class Meta:
+    class Meta(object):
         queryset = documents.UnregisteredCompany.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
@@ -97,7 +98,7 @@ class UnregisteredCompanyResource(resources.MongoEngineResource):
 
 
 class ContactResource(resources.MongoEngineResource):
-    class Meta:
+    class Meta(object):
         queryset = documents.Contact.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
@@ -113,7 +114,7 @@ class ContactResource(resources.MongoEngineResource):
 class ContactGroupResource(resources.MongoEngineResource):
     contacts = fields.ReferencedListField(of='test_project.test_app.api.resources.ContactResource', attribute='contacts', null=True)
 
-    class Meta:
+    class Meta(object):
         queryset = documents.ContactGroup.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
@@ -122,21 +123,21 @@ class ContactGroupResource(resources.MongoEngineResource):
 class CustomerResource(resources.MongoEngineResource):
     person = fields.ReferenceField(to='test_project.test_app.api.resources.PersonResource', attribute='person', full=True)
 
-    class Meta:
+    class Meta(object):
         queryset = documents.Customer.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
 
 
 class EmbeddedCommentResource(resources.MongoEngineResource):
-    class Meta:
+    class Meta(object):
         object_class = documents.EmbeddedComment
 
 
 class EmbeddedPostResource(resources.MongoEngineResource):
     comments = fields.EmbeddedListField(of='test_project.test_app.api.resources.EmbeddedCommentResource', attribute='comments', full=True, null=True)
 
-    class Meta:
+    class Meta(object):
         object_class = documents.EmbeddedPost
         ordering = ('title', 'comments')
 
@@ -144,14 +145,14 @@ class EmbeddedPostResource(resources.MongoEngineResource):
 class BoardResource(resources.MongoEngineResource):
     posts = fields.EmbeddedListField(of='test_project.test_app.api.resources.EmbeddedPostResource', attribute='posts', full=True, null=True)
 
-    class Meta:
+    class Meta(object):
         queryset = documents.Board.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
 
 
 class EmbeddedCommentWithIDResource(resources.MongoEngineResource):
-    class Meta:
+    class Meta(object):
         object_class = documents.EmbeddedCommentWithID
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
@@ -161,7 +162,7 @@ class EmbeddedCommentWithIDResource(resources.MongoEngineResource):
 class DocumentWithIDResource(resources.MongoEngineResource):
     comments = fields.EmbeddedListField(of='test_project.test_app.api.resources.EmbeddedCommentWithIDResource', attribute='comments', full=True, null=True)
 
-    class Meta:
+    class Meta(object):
         queryset = documents.DocumentWithID.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
@@ -170,7 +171,7 @@ class DocumentWithIDResource(resources.MongoEngineResource):
 class EmbeddedListInEmbeddedDocTestResource(resources.MongoEngineResource):
     post = fields.EmbeddedDocumentField(embedded='test_project.test_app.api.resources.EmbeddedPostResource', attribute='post')
 
-    class Meta:
+    class Meta(object):
         queryset = documents.EmbeddedListInEmbeddedDocTest.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
@@ -179,14 +180,14 @@ class EmbeddedListInEmbeddedDocTestResource(resources.MongoEngineResource):
 class EmbeddedDocumentFieldTestResource(resources.MongoEngineResource):
     customer = fields.EmbeddedDocumentField(embedded='test_project.test_app.api.resources.EmbeddedPersonResource', attribute='customer', null=True)
 
-    class Meta:
+    class Meta(object):
         queryset = documents.EmbeddedDocumentFieldTest.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
 
 
 class DictFieldTestResource(resources.MongoEngineResource):
-    class Meta:
+    class Meta(object):
         queryset = documents.DictFieldTest.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
@@ -195,7 +196,7 @@ class DictFieldTestResource(resources.MongoEngineResource):
 class ListFieldTestResource(resources.MongoEngineResource):
     extra_list = tastypie_fields.ListField()
 
-    class Meta:
+    class Meta(object):
         queryset = documents.ListFieldTest.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
@@ -204,7 +205,7 @@ class ListFieldTestResource(resources.MongoEngineResource):
 class EmbeddedListFieldTestResource(resources.MongoEngineResource):
     embeddedlist = fields.EmbeddedListField(of='test_project.test_app.api.resources.EmbeddedPersonResource', attribute='embeddedlist', full=True, null=True)
 
-    class Meta:
+    class Meta(object):
         queryset = documents.EmbeddedListFieldTest.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
@@ -214,7 +215,7 @@ class EmbeddedListFieldTestResource(resources.MongoEngineResource):
 class EmbeddedListFieldNonFullTestResource(resources.MongoEngineResource):
     embeddedlist = fields.EmbeddedListField(of='test_project.test_app.api.resources.EmbeddedPersonResource', attribute='embeddedlist', full=False, null=True)
 
-    class Meta:
+    class Meta(object):
         queryset = documents.EmbeddedListFieldTest.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
@@ -223,7 +224,7 @@ class EmbeddedListFieldNonFullTestResource(resources.MongoEngineResource):
 class ReferencedListFieldTestResource(resources.MongoEngineResource):
     referencedlist = fields.ReferencedListField(of='test_project.test_app.api.resources.PersonResource', attribute='referencedlist', full=True, null=True)
 
-    class Meta:
+    class Meta(object):
         queryset = documents.ReferencedListFieldTest.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
@@ -232,7 +233,7 @@ class ReferencedListFieldTestResource(resources.MongoEngineResource):
 class ReferencedListFieldNonFullTestResource(resources.MongoEngineResource):
     referencedlist = fields.ReferencedListField(of='test_project.test_app.api.resources.PersonResource', attribute='referencedlist', full=False, null=True)
 
-    class Meta:
+    class Meta(object):
         queryset = documents.ReferencedListFieldTest.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
@@ -241,7 +242,7 @@ class ReferencedListFieldNonFullTestResource(resources.MongoEngineResource):
 class BooleanMapTestResource(resources.MongoEngineResource):
     is_published_defined = tastypie_fields.BooleanField(default=False, null=False, attribute='is_published_defined')
 
-    class Meta:
+    class Meta(object):
         queryset = documents.BooleanMapTest.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
@@ -250,7 +251,7 @@ class BooleanMapTestResource(resources.MongoEngineResource):
 class EmbeddedListWithFlagFieldTestResource(resources.MongoEngineResource):
     embeddedlist = fields.EmbeddedListField(of='test_project.test_app.api.resources.EmbeddedPersonResource', attribute='embeddedlist', full=True, null=True)
 
-    class Meta:
+    class Meta(object):
         queryset = documents.EmbeddedListWithFlagFieldTest.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
@@ -259,14 +260,14 @@ class EmbeddedListWithFlagFieldTestResource(resources.MongoEngineResource):
 class AutoAllocationFieldTestResource(resources.MongoEngineResource):
     slug = tastypie_fields.CharField(readonly=True, attribute='slug')
 
-    class Meta:
+    class Meta(object):
         queryset = documents.AutoAllocationFieldTest.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
 
 
 class ExporterResource(resources.MongoEngineResource):
-    class Meta:
+    class Meta(object):
         queryset = documents.Exporter.objects.all()
         resource_name = 'exporters'
         allowed_methods = ('get', 'post', 'put', 'delete')
@@ -276,14 +277,14 @@ class ExporterResource(resources.MongoEngineResource):
 class EmbeddedExporterListResource(resources.MongoEngineResource):
     exporter = fields.ReferenceField(to='test_project.test_app.api.resources.ExporterResource', attribute='exporter', full=True)
 
-    class Meta:
+    class Meta(object):
         object_class = documents.PipeExporterEmbedded
 
 
 class PipeResource(resources.MongoEngineResource):
     exporters = fields.EmbeddedListField(of='test_project.test_app.api.resources.EmbeddedExporterListResource', attribute='exporters', full=True, null=True)
 
-    class Meta:
+    class Meta(object):
         queryset = documents.Pipe.objects.all()
         resource_name = 'pipes'
         allowed_methods = ('get', 'post', 'put', 'delete')
@@ -291,35 +292,35 @@ class PipeResource(resources.MongoEngineResource):
 
 
 class BlankableEmbeddedResource(resources.MongoEngineResource):
-    class Meta:
+    class Meta(object):
         object_class = documents.BlankableEmbedded
 
 
 class BlankableParentResource(resources.MongoEngineResource):
     embedded = fields.EmbeddedDocumentField(embedded='test_project.test_app.api.resources.BlankableEmbeddedResource', attribute='embedded', blank=True)
 
-    class Meta:
+    class Meta(object):
         queryset = documents.BlankableParent.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
 
 
 class TimezonedDateTimeResource(resources.MongoEngineResource):
-    class Meta:
+    class Meta(object):
         object_class = documents.TimezonedDateTime
 
 
 class ReadonlyParentResource(resources.MongoEngineResource):
     tzdt = fields.EmbeddedDocumentField(embedded='test_project.test_app.api.resources.TimezonedDateTimeResource', attribute='tzdt', readonly=True)
 
-    class Meta:
+    class Meta(object):
         queryset = documents.ReadonlyParent.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()
 
 
 class DatetimeFieldTestResource(resources.MongoEngineResource):
-    class Meta:
+    class Meta(object):
         queryset = documents.DatetimeFieldTest.objects.all()
         allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
         authorization = tastypie_authorization.Authorization()

--- a/tests/test_project/test_app/tests/test_basic.py
+++ b/tests/test_project/test_app/tests/test_basic.py
@@ -1,6 +1,10 @@
+from future import standard_library
+standard_library.install_aliases()
+from builtins import range
+from builtins import object
 from __future__ import with_statement
 
-import urlparse
+import urllib.parse
 
 from django.core import exceptions, urlresolvers
 from django.test import client, utils
@@ -36,8 +40,8 @@ class BasicTest(test_runner.MongoEngineTestCase):
         return urlresolvers.reverse('api_dispatch_detail', kwargs={'api_name': self.api_name, 'resource_name': resource_name, 'pk': resource_pk})
 
     def fullURItoAbsoluteURI(self, uri):
-        scheme, netloc, path, query, fragment = urlparse.urlsplit(uri)
-        return urlparse.urlunsplit((None, None, path, query, fragment))
+        scheme, netloc, path, query, fragment = urllib.parse.urlsplit(uri)
+        return urllib.parse.urlunsplit((None, None, path, query, fragment))
 
     def test_basic(self):
         # Testing POST
@@ -1178,7 +1182,7 @@ class BasicTest(test_runner.MongoEngineTestCase):
     def test_polymorphic_duplicate_class(self):
         with self.assertRaises(exceptions.ImproperlyConfigured):
             class DuplicateSubtypePersonResource(tastypie_mongoengine_resources.MongoEngineResource):
-                class Meta:
+                class Meta(object):
                     queryset = documents.Person.objects.all()
                     allowed_methods = ('get', 'post', 'put', 'patch', 'delete')
                     authorization = tastypie_authorization.Authorization()


### PR DESCRIPTION
SortedDict is deprecated in Django 1.9. See https://code.djangoproject.com/wiki/SortedDict
